### PR TITLE
Intégration de l'assistant de téléchargement dans les pages des données

### DIFF
--- a/components/cadastre-etalab.js
+++ b/components/cadastre-etalab.js
@@ -14,7 +14,7 @@ const products = [
       'sections',
       'feuilles',
       'parcelles',
-      'bâtiments'
+      'batiments'
     ]
   }
 ]

--- a/components/cadastre-etalab.js
+++ b/components/cadastre-etalab.js
@@ -1,5 +1,23 @@
 import Section from './section'
 import Ressource from './ressource'
+import DownloadAssistant from './download-assistant/download-assistant'
+
+const products = [
+  {
+    name: 'Cadastre Etalab',
+    formats: [
+      'geojson',
+      'geojson/gz'
+    ],
+    layers: [
+      'communes',
+      'sections',
+      'feuilles',
+      'parcelles',
+      'bâtiments'
+    ]
+  }
+]
 
 const CadastreEtalab = () => (
   <div>
@@ -78,6 +96,9 @@ const CadastreEtalab = () => (
           format='geojson'
           link='https://cadastre.data.gouv.fr/data/etalab-cadastre/2017-07-06/' />
       </div>
+    </Section>
+    <Section title='Assistant de téléchargement'>
+      <DownloadAssistant productList={products} />
     </Section>
     <style jsx>{`
       .ressources {

--- a/components/datasets.js
+++ b/components/datasets.js
@@ -1,6 +1,5 @@
 import FlaskIcon from 'react-icons/lib/fa/flask'
 import MapIcon from 'react-icons/lib/fa/map-o'
-import DownloadIcon from 'react-icons/lib/fa/download'
 import ThIcon from 'react-icons/lib/fa/th'
 
 import Section from './section'
@@ -24,12 +23,6 @@ const titles = [
     href: '/datasets/cadastre-strasbourg',
     subtitle: '[insert description here]',
     icon: <MapIcon />
-  },
-  {
-    title: 'Assistant de téléchargement',
-    href: '/datasets/download-assistant',
-    subtitle: '[insert description here]',
-    icon: <DownloadIcon />
   }
 ]
 

--- a/components/download-assistant/download-assistant.js
+++ b/components/download-assistant/download-assistant.js
@@ -1,5 +1,5 @@
+import PropTypes from 'prop-types'
 import React from 'react'
-import Router from 'next/router'
 
 import theme from '../../styles/theme'
 
@@ -10,8 +10,8 @@ class DownloadAssistant extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      product: null,
-      layer: null,
+      product: props.productList.length === 1 ? props.productList[0] : null,
+      layer: props.productList[0].name === 'Cadastre Etalab' ? 'communes' : null,
       territory: null,
       territoryType: null,
       format: null,
@@ -97,11 +97,13 @@ class DownloadAssistant extends React.Component {
   }
 
   render() {
+    const {productList} = this.props
     const {product, territoryType, territory, format, layer, url, downloadable, error} = this.state
 
     return (
       <div>
         <DownloadForm
+          productList={productList}
           product={product}
           territoryType={territoryType}
           territory={territory}
@@ -131,6 +133,10 @@ class DownloadAssistant extends React.Component {
       </div>
     )
   }
+}
+
+DownloadAssistant.propTypes = {
+  productList: PropTypes.array.isRequired
 }
 
 export default DownloadAssistant

--- a/components/download-assistant/download-assistant.js
+++ b/components/download-assistant/download-assistant.js
@@ -118,7 +118,7 @@ class DownloadAssistant extends React.Component {
 
         {downloadable && <DownloadButton href={url} />}
         {error &&
-          <div className='error-msg'>Il semblerait que cette ressource ne soit pas disponible.</div>
+          <div className='error-msg'>Cette ressource n’est pas disponible sur ce territoire.</div>
         }
 
         <style jsx>{`

--- a/components/download-assistant/download-assistant.js
+++ b/components/download-assistant/download-assistant.js
@@ -33,7 +33,7 @@ class DownloadAssistant extends React.Component {
       product: product === this.state.product ? null : product,
       layer: product.name === 'Cadastre Etalab' ? 'communes' : null,
       format: product.name === 'PCI Image' ? 'tiff' : null
-    }, () => Router.push('/datasets/download-assistant#territory'))
+    })
   }
 
   toggleTerritoryType(territoryType) {
@@ -44,11 +44,11 @@ class DownloadAssistant extends React.Component {
   }
 
   toggleTerritory(territory) {
-    this.setState({territory: territory === this.state.territory ? null : territory}, () => Router.push('/datasets/download-assistant#format'))
+    this.setState({territory: territory === this.state.territory ? null : territory})
   }
 
   toggleFormat(format) {
-    this.setState({format: format === this.state.format ? null : format}, () => Router.push('/datasets/download-assistant#download'))
+    this.setState({format: format === this.state.format ? null : format})
   }
 
   toggleLayer(layer) {

--- a/components/download-assistant/download-form.js
+++ b/components/download-assistant/download-form.js
@@ -17,27 +17,28 @@ class DownloadForm extends React.Component {
   }
 
   render() {
-    const {setLayer, setProduct, setTerritoryType, setTerritory, setFormat} = this.props
+    const {productList, setLayer, setProduct, setTerritoryType, setTerritory, setFormat} = this.props
     const {product, territoryType, territory, format, layer} = this.props
 
     return (
       <Section>
-        <Step id='product' title='1. Sélectionner un produit' disabled={false}>
+        {productList.length > 1 && <Step id='product' title='Sélectionner un produit' disabled={false}>
           <ProductSelection
+            products={productList}
             productSelected={product}
             layer={layer}
             toggleLayer={setLayer}
             selectProduct={setProduct} />
-        </Step>
+        </Step>}
 
-        <Step id='territory' title='2. Sélectionner un territoire' disabled={Boolean(!product)}>
+        <Step id='territory' title='Sélectionner un territoire' disabled={Boolean(!product)}>
           <TerritorySelection
             territorySelected={territoryType}
             selectTerritoryType={setTerritoryType}
             selectTerritory={setTerritory} />
         </Step>
 
-        <Step id='format' title='3. Sélectionner un format' disabled={Boolean(!territory)}>
+        <Step id='format' title='Sélectionner un format' disabled={Boolean(!territory)}>
           <Selector
             items={product && territory ? product.formats : []}
             selected={format}
@@ -58,6 +59,7 @@ DownloadForm.propTypes = {
   territory: PropTypes.object,
   format: PropTypes.string,
   layer: PropTypes.string,
+  productList: PropTypes.array.isRequired,
   setLayer: PropTypes.func.isRequired,
   setProduct: PropTypes.func.isRequired,
   setTerritoryType: PropTypes.func.isRequired,

--- a/components/download-assistant/download-form.js
+++ b/components/download-assistant/download-form.js
@@ -41,7 +41,6 @@ class DownloadForm extends React.Component {
           <Selector
             items={product && territory ? product.formats : []}
             selected={format}
-            unavailable={['edigeo/cc']}
             uppercase
             handleSelect={setFormat} />
           {product && product.name === 'Cadastre Etalab' &&

--- a/components/download-assistant/product-selection.js
+++ b/components/download-assistant/product-selection.js
@@ -31,12 +31,6 @@ const products = [
       'parcelles',
       'bâtiments'
     ]
-  },
-  {
-    name: 'Cadastre Strasbourg',
-    formats: [
-      'shp/cc49'
-    ]
   }
 ]
 
@@ -65,7 +59,6 @@ class ProductSelection extends React.Component {
         <Selector
           items={products.map(product => product.name)}
           selected={productSelected ? productSelected.name : null}
-          unavailable={['Cadastre Strasbourg']}
           handleSelect={this.select} />
       </div>
     )

--- a/components/download-assistant/product-selection.js
+++ b/components/download-assistant/product-selection.js
@@ -3,37 +3,6 @@ import PropTypes from 'prop-types'
 
 import Selector from '../selector'
 
-const products = [
-  {
-    name: 'PCI Vecteur',
-    formats: [
-      'dxf',
-      'edigeo',
-      'edigeo/cc'
-    ]
-  },
-  {
-    name: 'PCI Image',
-    formats: [
-      'tiff'
-    ]
-  },
-  {
-    name: 'Cadastre Etalab',
-    formats: [
-      'geojson',
-      'geojson/gz'
-    ],
-    layers: [
-      'communes',
-      'sections',
-      'feuilles',
-      'parcelles',
-      'bâtiments'
-    ]
-  }
-]
-
 class ProductSelection extends React.Component {
   constructor(props) {
     super(props)
@@ -41,7 +10,7 @@ class ProductSelection extends React.Component {
   }
 
   select(item) {
-    const {selectProduct, toggleLayer} = this.props
+    const {products, selectProduct, toggleLayer} = this.props
     const product = products.find(p => p.name === item)
 
     if (item === 'Cadastre Etalab') {
@@ -52,7 +21,7 @@ class ProductSelection extends React.Component {
   }
 
   render() {
-    const {productSelected} = this.props
+    const {products, productSelected} = this.props
 
     return (
       <div>
@@ -66,6 +35,7 @@ class ProductSelection extends React.Component {
 }
 
 ProductSelection.propTypes = {
+  products: PropTypes.array.isRequired,
   selectProduct: PropTypes.func.isRequired,
   toggleLayer: PropTypes.func.isRequired,
   productSelected: PropTypes.object

--- a/components/pci.js
+++ b/components/pci.js
@@ -1,5 +1,23 @@
 import Section from './section'
 import Ressource from './ressource'
+import DownloadAssistant from './download-assistant/download-assistant'
+
+const products = [
+  {
+    name: 'PCI Vecteur',
+    formats: [
+      'dxf',
+      'edigeo',
+      'edigeo/cc'
+    ]
+  },
+  {
+    name: 'PCI Image',
+    formats: [
+      'tiff'
+    ]
+  }
+]
 
 const Pci = () => (
   <div>
@@ -78,6 +96,9 @@ const Pci = () => (
           format='edigeo'
           link='https://cadastre.data.gouv.fr/data/dgfip-pci-vecteur/2017-02-13/' />
       </div>
+    </Section>
+    <Section title='Assistant de téléchargement'>
+      <DownloadAssistant productList={products} />
     </Section>
     <style jsx>{`
       .ressources {


### PR DESCRIPTION
L'assistant de téléchargement est retiré de `/datasets` afin d'être directement intégré directement dans les pages de données.

La sélection du "produit" est donc automatiquement rempli est invisible pour l'utilisateur. De cette façon l'assistant de téléchargement est toujours utilisable en "stand alone" si jamais le besoin se fait sentir.

Modifications : 
- Le format EDIGEO-CC est désormais disponible
- Le link vers la prochaine étape du formulaire a été retiré