### PR TITLE
Changement graphique mineur bloc en-tête

### DIFF
--- a/components/cadastre-etalab.js
+++ b/components/cadastre-etalab.js
@@ -23,6 +23,13 @@ const CadastreEtalab = () => (
   <div>
     <Section>
       <div className='main'>
+
+        <h4>Divisions</h4>
+        <p>
+          Chaque commune est subdivisée en sections, elles-mêmes subdivisées en feuilles (ou planches).
+          Une feuille cadastrale comporte des parcelles, qui peuvent supporter des bâtiments.
+        </p>
+
         <h4>Différence par rapport au PCI Vecteur</h4>
 
         <p>Contrairement au <a href='https://www.data.gouv.fr/fr/datasets/58e5924b88ee3802ca255566/'>Plan Cadastral Informatisé</a> au format EDIGÉO qui est un ensemble de 600 000 feuilles cadastrales avec de nombreux éléments liés à la fiscalité ou à l’habillage du plan, cette version retravaillée par Etalab se concentre sur le découpage parcellaire et sur les bâtiments.</p>

--- a/components/cadastre-strasbourg.js
+++ b/components/cadastre-strasbourg.js
@@ -5,6 +5,7 @@ const CadastreStrasbourg = () => (
   <div>
     <Section>
       <div className='main'>
+        <p>Créée le 4 décembre 1967 sous le nom de communauté urbaine de Strasbourg (CUS), elle devient une métropole le 1er janvier 2015.</p>
 
         <p>Ce jeu de données contient principalement les parcelles cadastrales gérées par le service Géomatique et Connaissance du Territoire de l’Eurométropole de Strasbourg sur le territoire de la collectivité.
         Les parcelles sont issues d’opérations de calcul basée sur les croquis cadastraux ce qui permet d’atteindre une bonne précision géométrique des données.</p>

--- a/components/datasets.js
+++ b/components/datasets.js
@@ -19,7 +19,7 @@ const titles = [
     icon: <FlaskIcon />
   },
   {
-    title: 'Cadastrales Eurométropole de Strasbourg',
+    title: 'Cadastre Eurométropole de Strasbourg',
     href: '/datasets/cadastre-strasbourg',
     subtitle: '[insert description here]',
     icon: <MapIcon />

--- a/components/datasets.js
+++ b/components/datasets.js
@@ -19,7 +19,7 @@ const titles = [
     icon: <FlaskIcon />
   },
   {
-    title: 'Données cadastrales Eurométropole de Strasbourg',
+    title: 'Cadastrales Eurométropole de Strasbourg',
     href: '/datasets/cadastre-strasbourg',
     subtitle: '[insert description here]',
     icon: <MapIcon />

--- a/components/head.js
+++ b/components/head.js
@@ -11,7 +11,7 @@ const Head = ({children, title, icon}) => (
         <div className='icon'>{icon}</div>
         <div className='text'>
           <h1>{title}</h1>
-          <div className='description'>{children}</div>
+          <p className='description'>{children}</p>
         </div>
       </div>
     </Container>

--- a/components/head.js
+++ b/components/head.js
@@ -17,7 +17,7 @@ const Head = ({children, title, icon}) => (
     </Container>
     <style jsx>{`
       .head {
-        background-color: ${theme.backgroundDark};
+        background-color: ${theme.backgroundColor};
       }
 
       .row {

--- a/components/pci.js
+++ b/components/pci.js
@@ -23,6 +23,11 @@ const Pci = () => (
   <div>
     <Section>
       <div>
+        <h4>Divisions</h4>
+        <p>Chaque commune est subdivisée en sections, elles-mêmes subdivisées en feuilles (ou planches).
+    Une feuille cadastrale comporte des parcelles, qui peuvent supporter des bâtiments, ainsi que de nombreux autres objets d’habillage ou de gestion.</p>
+        <p>Pour plus de précision, veuillez vous reporter à la documentation du <a href='https://www.data.gouv.fr/s/resources/plan-cadastral-informatise/20170906-150737/standard_edigeo_2013.pdf'>standard EDIGÉO</a>.</p>
+
         <h4>Couverture</h4>
         <p>32 864 communes sont couvertes par le PCI Vecteur, sur un total de près de 36 000.
         Les plans des autres communes sont disponibles sous forme d’images, via le PCI Image (diffusion prévue courant octobre).</p>

--- a/pages/datasets/cadastre-etalab.js
+++ b/pages/datasets/cadastre-etalab.js
@@ -10,11 +10,7 @@ const description = 'Le plan cadastral est le découpage du territoire français
 export default () => (
   <Page title={title} description={description}>
     <Head title={title} icon={<FlaskIcon />}>
-      <div>
-        <p>{description}</p>
-        <p>Chaque commune est subdivisée en sections, elles-mêmes subdivisées en feuilles (ou planches).
-          Une feuille cadastrale comporte des parcelles, qui peuvent supporter des bâtiments.</p>
-      </div>
+      {description}
     </Head>
     <CadastreEtalab />
   </Page>

--- a/pages/datasets/cadastre-strasbourg.js
+++ b/pages/datasets/cadastre-strasbourg.js
@@ -4,7 +4,7 @@ import Page from '../../layouts/main'
 import Head from '../../components/head'
 import CadastreStrasbourg from '../../components/cadastre-strasbourg'
 
-const title = 'Données cadastrales Eurométropole de Strasbourg'
+const title = 'Cadastrales Eurométropole de Strasbourg'
 const description = 'L’Eurométropole de Strasbourg est une métropole française située dans le département du Bas-Rhin. Elle fait partie du pôle métropolitain Strasbourg-Mulhouse-Colmar qui fédère les grandes intercommunalités alsaciennes.'
 
 export default () => (

--- a/pages/datasets/cadastre-strasbourg.js
+++ b/pages/datasets/cadastre-strasbourg.js
@@ -10,10 +10,7 @@ const description = 'L’Eurométropole de Strasbourg est une métropole frança
 export default () => (
   <Page title={title} description={description}>
     <Head title={title} icon={<MapIcon />}>
-      <div>
-        <p>{description}</p>
-        <p>Créée le 4 décembre 1967 sous le nom de communauté urbaine de Strasbourg (CUS), elle devient une métropole le 1er janvier 2015.</p>
-      </div>
+      {description}
     </Head>
     <CadastreStrasbourg />
   </Page>

--- a/pages/datasets/cadastre-strasbourg.js
+++ b/pages/datasets/cadastre-strasbourg.js
@@ -4,7 +4,7 @@ import Page from '../../layouts/main'
 import Head from '../../components/head'
 import CadastreStrasbourg from '../../components/cadastre-strasbourg'
 
-const title = 'Cadastrales Eurométropole de Strasbourg'
+const title = 'Cadastre Eurométropole de Strasbourg'
 const description = 'L’Eurométropole de Strasbourg est une métropole française située dans le département du Bas-Rhin. Elle fait partie du pôle métropolitain Strasbourg-Mulhouse-Colmar qui fédère les grandes intercommunalités alsaciennes.'
 
 export default () => (

--- a/pages/datasets/index.js
+++ b/pages/datasets/index.js
@@ -10,7 +10,7 @@ const description = 'cadaste.data.gouv.fr met en place des outils pour une prise
 export default () => (
   <Page title={title} description={description}>
     <Head title={title} icon={<DownloadIcon />}>
-      <div><p>{description}</p></div>
+      {description}
     </Head>
     <Datasets />
   </Page>

--- a/pages/datasets/pci.js
+++ b/pages/datasets/pci.js
@@ -10,13 +10,15 @@ const description = 'Le plan cadastral est le découpage du territoire français
 export default () => (
   <Page title={title} description={description}>
     <Head title={title} icon={<ThIcon />}>
-      <div>
-        <p>Le plan cadastral est le découpage du territoire français en unités de surfaces permettant le calcul de certains impôts (notamment la taxe foncière, la taxe d’habitation et la cotisation foncière des entreprises). La consultation du cadastre peut se faire en ligne sur <a href='https://cadastre.gouv.fr' rel='nofollow'>cadastre.gouv.fr</a>.</p>
-        <p>Chaque commune est subdivisée en sections, elles-mêmes subdivisées en feuilles (ou planches).
-    Une feuille cadastrale comporte des parcelles, qui peuvent supporter des bâtiments, ainsi que de nombreux autres objets d’habillage ou de gestion.</p>
-        <p>Pour plus de précision, veuillez vous reporter à la documentation du <a href='https://www.data.gouv.fr/s/resources/plan-cadastral-informatise/20170906-150737/standard_edigeo_2013.pdf'>standard EDIGÉO</a>.</p>
-      </div>
+      Le plan cadastral est le découpage du territoire français en unités de surfaces permettant le calcul de certains impôts (notamment la taxe foncière, la taxe d’habitation et la cotisation foncière des entreprises). La consultation du cadastre peut se faire en ligne sur <a href='https://cadastre.gouv.fr' rel='nofollow'>cadastre.gouv.fr</a>.
     </Head>
     <Pci />
+    <style jsx>{`
+      a {
+        color: #fff;
+        text-decoration: underline;
+        font-weight: 600;
+      }
+      `}</style>
   </Page>
 )

--- a/pages/faq.js
+++ b/pages/faq.js
@@ -10,7 +10,7 @@ const description = 'Questions les plus fréquemment posées.'
 export default () => (
   <Page title={title} description={description}>
     <Head title={title} icon={<FaQuestion />}>
-      <div><p>{description}</p></div>
+      {description}
     </Head>
     <Faq />
   </Page>


### PR DESCRIPTION
Changements:
- couleur de fond
- description réduite à un paragraphe

Autres modifications :
- `Données cadastrales Eurométropole de Strasbourg` renommer `Cadastrales Eurométropole de Strasbourg`