### PR TITLE
Correction warning et affichage mobile du bandeau beta

### DIFF
--- a/components/section.js
+++ b/components/section.js
@@ -74,6 +74,12 @@ const Section = ({title, subtitle, children, background, beta}) => {
           background: ${theme.backgroundColor};
           box-shadow: 0 3px 10px -5px ${theme.boxShadow};
         }
+
+        @media (min-width: 370px) and (max-width: 450px) {
+          .section__title {
+            margin: 0 1em 3em;
+          }
+        }
       `}</style>
     </section>
   )

--- a/components/section.js
+++ b/components/section.js
@@ -83,7 +83,7 @@ Section.propTypes = {
   title: PropTypes.string,
   subtitle: PropTypes.string,
   children: PropTypes.node,
-  beta: PropTypes.boolean,
+  beta: PropTypes.bool,
   background: PropTypes.oneOf([
     'white',
     'grey',


### PR DESCRIPTION
#### Warning `PropTypes`
`Section: prop type `beta` is invalid` 

#### Affichage sur mobile entre `370px` et `377px`
<img width="299" alt="capture d ecran 2017-12-22 a 13 04 03" src="https://user-images.githubusercontent.com/7040549/34297469-a039fd6c-e718-11e7-9c8b-2dfe4962fd42.png">
