### PR TITLE
Export statique du site

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,5 +13,17 @@ module.exports = {
     }
 
     return config
+  },
+
+  exportPathMap() {
+    return {
+      '/': {page: '/'},
+      '/datasets': {page: '/datasets'},
+      '/mentions-legales': {page: '/mentions-legales'},
+      '/faq': {page: '/faq'},
+      '/datasets/plan-cadastral-informatise': {page: '/datasets/plan-cadastral-informatise'},
+      '/datasets/cadastre-strasbourg': {page: '/datasets/cadastre-strasbourg'},
+      '/datasets/cadastre-etalab': {page: '/datasets/cadastre-etalab'}
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "node server",
     "build": "next build",
+    "export": "next export",
     "start": "NODE_ENV=production node server",
     "test": "NODE_ENV=test jest",
     "lint": "xo",


### PR DESCRIPTION
Aucune route dynamique n'étant actuellement implémentée, le site est toujours exportable en site statique.
Cette configuration y veille.