### PR TITLE
N'affiche la contenance que lorsqu'elle est définie

### DIFF
--- a/components/map/parcelle-sumup.js
+++ b/components/map/parcelle-sumup.js
@@ -9,10 +9,10 @@ const ParcelleSumup = ({prefixe, section, numero, contenance}) => (
       <span className='title'>Parcelle </span>
       <span>{(prefixe === '000') ? '' : prefixe} {section} {numero}</span>
     </div>
-    <div>
+    {contenance && <div>
       <span className='title'>Contenance </span>
       <span>{contenanceToSurface(contenance)}</span>
-    </div>
+    </div>}
     <style jsx>{`
         .sumup-container {
           font-size: larger;

--- a/components/map/parcelle.js
+++ b/components/map/parcelle.js
@@ -29,7 +29,7 @@ const Parcelle = ({parcelle, close}) => {
       <div className='content'>
         <div><b>Section</b> : {(prefixe === '000') ? '' : prefixe} {section}</div>
         <div><b>Commune</b> : {commune ? `${commune.nom} - ${commune.code}` : '…'}</div>
-        <div><b>Contenance cadastrale</b> : {contenanceToSurface(contenance)}</div>
+        {contenance && <div><b>Contenance cadastrale</b> : {contenanceToSurface(contenance)}</div>}
       </div>
       <style jsx>{`
         .parcelle-container {


### PR DESCRIPTION
Sur la métropole de Strasbourg, la contenance n'est pas définie car l'information ne provient pas des services du cadastre.

Pour le moment on masque cette partie, par la suite on pourra remplacer par une surface graphique.

<img width="1322" alt="Capture d’écran 2020-02-17 à 15 56 12" src="https://user-images.githubusercontent.com/1231232/74664519-296e5280-519e-11ea-90c3-7d370c912e1e.png">
