### PR TITLE
Update description and references to latest cadastre data e.g 2026-03-01

### DIFF
--- a/components/cadastre-etalab.js
+++ b/components/cadastre-etalab.js
@@ -40,7 +40,8 @@ const historique = [
   ['27/01/2025', 'nouveau millésime PCI janvier 2025 + nouvelles données Strasbourg'],
   ['23/04/2025', 'nouveau millésime PCI avril 2025 + nouvelles données Strasbourg'],
   ['29/09/2025', 'nouveau millésime PCI septembre 2025. Données de strasbourg non intégrées car entièrement intégrées dans PCI maintenant'],
-  ['08/01/2026', 'nouveau millésime PCI décembre 2025. Données de strasbourg non intégrées car entièrement intégrées dans PCI maintenant']
+  ['08/01/2026', 'nouveau millésime PCI décembre 2025. Données de strasbourg non intégrées car entièrement intégrées dans PCI maintenant'],
+  ['09/04/2026', 'nouveau millésime PCI mars 2026. Données de strasbourg non intégrées car entièrement intégrées dans PCI maintenant']
 ]
 const listItemsHistorique = historique.slice().reverse().map(([dateMaj, comment]) => <li key={dateMaj}>{dateMaj} : {parse(comment)}</li>)
 

--- a/components/pci.js
+++ b/components/pci.js
@@ -72,7 +72,7 @@ function Pci() {
             <li>Via un outil en ligne pour les <b>archives communales</b>. Les données sont alors produites à la volée.</li>
           </ul>
           <p>Les deux modes de mise à disposition sont accessibles ci-dessous.</p>
-          <p>Les archives de <b>juillet 2017</b> à <b>janvier 2023</b> sont maintenant hébergées sur <a href='https://files.data.gouv.fr/cadastre/'>https://files.data.gouv.fr/cadastre/</a></p>
+          <p>Les archives de <b>juillet 2017</b> à <b>avril 2023</b> sont maintenant hébergées sur <a href='https://files.data.gouv.fr/cadastre/'>https://files.data.gouv.fr/cadastre/</a></p>
 
           <h4>Outils</h4>
 

--- a/lib/cadastre-etalab.mjs
+++ b/lib/cadastre-etalab.mjs
@@ -1,12 +1,23 @@
 export const downloadUrls = {
   current: 'https://cadastre.data.gouv.fr/data/etalab-cadastre',
   old: 'https://files.data.gouv.fr/cadastre/etalab-cadastre',
-  minio: 'https://object.infra.data.gouv.fr/browser/cadastre/etalab-cadastre'
+  s3public: 'https://cadastre-files.data.gouv.fr/etalab-cadastre'
 }
 
 export const millesimes = [
   {
     latest: true,
+    date: '1er mars 2025',
+    path: '2026-03-01',
+    baseUrl: downloadUrls.current,
+    formats: [
+      {name: 'geojson', granularities: ['communes', 'epcis', 'departements', 'france']},
+      {name: 'shp', granularities: ['departements', 'france']},
+      {name: 'geoparquet', granularities: ['france']},
+      {name: 'mbtiles', granularities: ['france']}
+    ]
+  },
+  {
     date: '1er décembre 2025',
     path: '2025-12-01',
     baseUrl: downloadUrls.current,
@@ -275,7 +286,7 @@ export const millesimes = [
   {
     date: '1er octobre 2018',
     path: '2018-10-01',
-    baseUrl: downloadUrls.old,
+    baseUrl: downloadUrls.s3public,
     formats: [
       {name: 'geojson', granularities: ['communes']},
       {name: 'shp', granularities: ['departements', 'france']}
@@ -284,7 +295,7 @@ export const millesimes = [
   {
     date: '29 juin 2018',
     path: '2018-06-29',
-    baseUrl: downloadUrls.old,
+    baseUrl: downloadUrls.s3public,
     formats: [
       {name: 'geojson', granularities: ['communes']},
       {name: 'shp', granularities: ['departements', 'france']}
@@ -293,7 +304,7 @@ export const millesimes = [
   {
     date: '3 avril 2018',
     path: '2018-04-03',
-    baseUrl: downloadUrls.old,
+    baseUrl: downloadUrls.s3public,
     formats: [
       {name: 'geojson', granularities: ['communes']},
       {name: 'shp', granularities: ['departements', 'france']}
@@ -302,7 +313,7 @@ export const millesimes = [
   {
     date: '2 janvier 2018',
     path: '2018-01-02',
-    baseUrl: downloadUrls.old,
+    baseUrl: downloadUrls.s3public,
     formats: [
       {name: 'geojson', granularities: ['communes']}
     ]
@@ -310,7 +321,7 @@ export const millesimes = [
   {
     date: '12 octobre 2017',
     path: '2017-10-12',
-    baseUrl: downloadUrls.old,
+    baseUrl: downloadUrls.s3public,
     formats: [
       {name: 'geojson', granularities: ['communes']}
     ]
@@ -318,7 +329,7 @@ export const millesimes = [
   {
     date: '6 juillet 2017',
     path: '2017-07-06',
-    baseUrl: downloadUrls.old,
+    baseUrl: downloadUrls.s3public,
     formats: [
       {name: 'geojson', granularities: ['communes']}
     ]

--- a/lib/pci.mjs
+++ b/lib/pci.mjs
@@ -1,12 +1,23 @@
 export const downloadUrls = {
   current: 'https://cadastre.data.gouv.fr/data',
   old: 'https://files.data.gouv.fr/cadastre',
-  minio: 'https://object.infra.data.gouv.fr/browser/cadastre'
+  s3public: 'https://cadastre-files.data.gouv.fr'
 }
 
 export const millesimes = [
   {
     latest: true,
+    date: '1er mars 2026',
+    path: '2026-03-01',
+    baseUrl: downloadUrls.current,
+    formats: [
+      {name: 'edigeo', granularities: ['feuilles', 'epcis', 'departements']},
+      {name: 'edigeo-cc', granularities: ['feuilles', 'epcis', 'departements']},
+      {name: 'dxf', granularities: ['feuilles', 'epcis', 'departements']},
+      {name: 'dxf-cc', granularities: ['feuilles', 'epcis', 'departements']}
+    ]
+  },
+  {
     date: '1er décembre 2025',
     path: '2025-12-01',
     baseUrl: downloadUrls.current,
@@ -331,7 +342,7 @@ export const millesimes = [
   {
     date: '1er octobre 2018',
     path: '2018-10-01',
-    baseUrl: downloadUrls.old,
+    baseUrl: downloadUrls.s3public,
     formats: [
       {name: 'edigeo', granularities: ['feuilles', 'departements']},
       {name: 'edigeo-cc', granularities: ['feuilles', 'departements']},
@@ -343,7 +354,7 @@ export const millesimes = [
   {
     date: '29 juin 2018',
     path: '2018-06-29',
-    baseUrl: downloadUrls.old,
+    baseUrl: downloadUrls.s3public,
     formats: [
       {name: 'edigeo', granularities: ['feuilles', 'departements']},
       {name: 'edigeo-cc', granularities: ['feuilles', 'departements']},
@@ -355,7 +366,7 @@ export const millesimes = [
   {
     date: '3 avril 2018',
     path: '2018-04-03',
-    baseUrl: downloadUrls.old,
+    baseUrl: downloadUrls.s3public,
     formats: [
       {name: 'edigeo', granularities: ['feuilles', 'departements']},
       {name: 'edigeo-cc', granularities: ['feuilles', 'departements']},
@@ -367,7 +378,7 @@ export const millesimes = [
   {
     date: '2 janvier 2018',
     path: '2018-01-02',
-    baseUrl: downloadUrls.old,
+    baseUrl: downloadUrls.s3public,
     formats: [
       {name: 'edigeo', granularities: ['feuilles', 'departements']},
       {name: 'edigeo-cc', granularities: ['feuilles', 'departements']},
@@ -379,7 +390,7 @@ export const millesimes = [
   {
     date: '12 octobre 2017',
     path: '2017-10-12',
-    baseUrl: downloadUrls.old,
+    baseUrl: downloadUrls.s3public,
     formats: [
       {name: 'edigeo', granularities: ['feuilles', 'departements']},
       {name: 'dxf', granularities: ['feuilles', 'departements']},
@@ -389,7 +400,7 @@ export const millesimes = [
   {
     date: '6 juillet 2017',
     path: '2017-07-06',
-    baseUrl: downloadUrls.old,
+    baseUrl: downloadUrls.s3public,
     formats: [
       {name: 'edigeo', granularities: ['feuilles', 'departements']}
     ]
@@ -397,7 +408,7 @@ export const millesimes = [
   {
     date: '14 mai 2017',
     path: '2017-05-14',
-    baseUrl: downloadUrls.old,
+    baseUrl: downloadUrls.s3public,
     formats: [
       {name: 'edigeo', granularities: ['feuilles', 'departements']}
     ]
@@ -405,7 +416,7 @@ export const millesimes = [
   {
     date: '13 février 2017',
     path: '2017-02-13',
-    baseUrl: downloadUrls.old,
+    baseUrl: downloadUrls.s3public,
     formats: [
       {name: 'edigeo', granularities: ['feuilles', 'departements']}
     ]


### PR DESCRIPTION
Change informations for both Etalab cadastre and pci vecteur as no pci raster anymore (cadastre fully vectorized for France)